### PR TITLE
Fixed nav button colors

### DIFF
--- a/grouplove/theme/love.css
+++ b/grouplove/theme/love.css
@@ -24,14 +24,14 @@ nav a:hover {
 }
 
 .dark { background-color: #154451; }
-.pink { background-color: #da5d86; }
-.blue { background-color: #1e86be; }
 .green { background-color: #25b786; }
+.blue { background-color: #1e86be; }
+.pink { background-color: #da5d86; }
 
 nav a:nth-child(1) { background-color: #154451; }
-nav a:nth-child(2) { background-color: #da5d86; }
+nav a:nth-child(2) { background-color: #25b786; }
 nav a:nth-child(3) { background-color: #1e86be; }
-nav a:nth-child(4) { background-color: #25b786; }
+nav a:nth-child(4) { background-color: #da5d86; }
 
 html {
 	background-color: #6cbee4;


### PR DESCRIPTION
The "Main" Navigation buttons' color scheme should now match with the ones on the Home page (sans the dark home page link, for obvious reasons). Text still differs though, but idk if that should be edited to match or not.